### PR TITLE
Add AiStudio provider

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -23,6 +23,7 @@ import { FireworksHandler } from "./providers/fireworks"
 import { AskSageHandler } from "./providers/asksage"
 import { XAIHandler } from "./providers/xai"
 import { SambanovaHandler } from "./providers/sambanova"
+import { AiStudioHandler } from "./providers/aistudio"
 
 export interface ApiHandler {
 	createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream
@@ -63,6 +64,8 @@ export function buildApiHandler(configuration: ApiConfiguration): ApiHandler {
 			return new FireworksHandler(options)
 		case "together":
 			return new TogetherHandler(options)
+		case "aistudio":
+			return new AiStudioHandler(options)
 		case "qwen":
 			return new QwenHandler(options)
 		case "doubao":

--- a/src/api/providers/aistudio.ts
+++ b/src/api/providers/aistudio.ts
@@ -1,0 +1,75 @@
+import { Anthropic } from "@anthropic-ai/sdk"
+import OpenAI from "openai"
+import { withRetry } from "../retry"
+import { ApiHandlerOptions, ModelInfo, openAiModelInfoSaneDefaults } from "@shared/api"
+import { ApiHandler } from "../index"
+import { convertToOpenAiMessages } from "@api/transform/openai-format"
+import { ApiStream } from "@api/transform/stream"
+import { convertToR1Format } from "@api/transform/r1-format"
+
+export class AiStudioHandler implements ApiHandler {
+	private options: ApiHandlerOptions
+	private client: OpenAI
+
+	constructor(options: ApiHandlerOptions) {
+		this.options = options
+		this.client = new OpenAI({
+			baseURL: "https://api.aistudio.com/v1",
+			apiKey: this.options.aistudioApiKey,
+		})
+	}
+
+	@withRetry()
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		const modelId = this.options.aistudioModelId ?? ""
+		const isDeepseekReasoner = modelId.includes("deepseek-reasoner")
+
+		let openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+			{ role: "system", content: systemPrompt },
+			...convertToOpenAiMessages(messages),
+		]
+
+		if (isDeepseekReasoner) {
+			openAiMessages = convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
+		}
+
+		const stream = await this.client.chat.completions.create({
+			model: modelId,
+			messages: openAiMessages,
+			temperature: 0,
+			stream: true,
+			stream_options: { include_usage: true },
+		})
+		for await (const chunk of stream) {
+			const delta = chunk.choices[0]?.delta
+			if (delta?.content) {
+				yield {
+					type: "text",
+					text: delta.content,
+				}
+			}
+
+			if (delta && "reasoning_content" in delta && (delta as any).reasoning_content) {
+				yield {
+					type: "reasoning",
+					reasoning: ((delta as any).reasoning_content as string | undefined) || "",
+				}
+			}
+
+			if (chunk.usage) {
+				yield {
+					type: "usage",
+					inputTokens: chunk.usage.prompt_tokens || 0,
+					outputTokens: chunk.usage.completion_tokens || 0,
+				}
+			}
+		}
+	}
+
+	getModel(): { id: string; info: ModelInfo } {
+		return {
+			id: this.options.aistudioModelId ?? "",
+			info: openAiModelInfoSaneDefaults,
+		}
+	}
+}

--- a/src/core/storage/state-keys.ts
+++ b/src/core/storage/state-keys.ts
@@ -20,6 +20,7 @@ export type SecretKey =
 	| "asksageApiKey"
 	| "xaiApiKey"
 	| "sambanovaApiKey"
+	| "aistudioApiKey"
 
 export type GlobalStateKey =
 	| "apiProvider"
@@ -77,6 +78,7 @@ export type GlobalStateKey =
 	| "requestyModelId"
 	| "requestyModelInfo"
 	| "togetherModelId"
+	| "aistudioModelId"
 	| "mcpMarketplaceCatalog"
 	| "telemetrySetting"
 	| "asksageApiUrl"

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -115,6 +115,8 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		requestyModelInfo,
 		togetherApiKey,
 		togetherModelId,
+		aistudioApiKey,
+		aistudioModelId,
 		qwenApiKey,
 		doubaoApiKey,
 		mistralApiKey,
@@ -202,6 +204,8 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		getGlobalState(context, "requestyModelInfo") as Promise<ModelInfo | undefined>,
 		getSecret(context, "togetherApiKey") as Promise<string | undefined>,
 		getGlobalState(context, "togetherModelId") as Promise<string | undefined>,
+		getSecret(context, "aistudioApiKey") as Promise<string | undefined>,
+		getGlobalState(context, "aistudioModelId") as Promise<string | undefined>,
 		getSecret(context, "qwenApiKey") as Promise<string | undefined>,
 		getSecret(context, "doubaoApiKey") as Promise<string | undefined>,
 		getSecret(context, "mistralApiKey") as Promise<string | undefined>,
@@ -329,6 +333,8 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 			requestyModelInfo,
 			togetherApiKey,
 			togetherModelId,
+			aistudioApiKey,
+			aistudioModelId,
 			qwenApiKey,
 			qwenApiLine,
 			doubaoApiKey,
@@ -424,6 +430,8 @@ export async function updateApiConfiguration(context: vscode.ExtensionContext, a
 		requestyModelInfo,
 		togetherApiKey,
 		togetherModelId,
+		aistudioApiKey,
+		aistudioModelId,
 		qwenApiKey,
 		doubaoApiKey,
 		mistralApiKey,
@@ -499,6 +507,8 @@ export async function updateApiConfiguration(context: vscode.ExtensionContext, a
 	await updateGlobalState(context, "requestyModelId", requestyModelId)
 	await updateGlobalState(context, "requestyModelInfo", requestyModelInfo)
 	await updateGlobalState(context, "togetherModelId", togetherModelId)
+	await storeSecret(context, "aistudioApiKey", aistudioApiKey)
+	await updateGlobalState(context, "aistudioModelId", aistudioModelId)
 	await storeSecret(context, "asksageApiKey", asksageApiKey)
 	await updateGlobalState(context, "asksageApiUrl", asksageApiUrl)
 	await updateGlobalState(context, "thinkingBudgetTokens", thinkingBudgetTokens)
@@ -534,6 +544,7 @@ export async function resetExtensionState(context: vscode.ExtensionContext) {
 		"asksageApiKey",
 		"xaiApiKey",
 		"sambanovaApiKey",
+		"aistudioApiKey",
 	]
 	for (const key of secretKeys) {
 		await storeSecret(context, key, undefined)

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -23,6 +23,7 @@ export type ApiProvider =
 	| "asksage"
 	| "xai"
 	| "sambanova"
+	| "aistudio"
 
 export interface ApiHandlerOptions {
 	apiModelId?: string
@@ -87,6 +88,8 @@ export interface ApiHandlerOptions {
 	thinkingBudgetTokens?: number
 	reasoningEffort?: string
 	sambanovaApiKey?: string
+	aistudioApiKey?: string
+	aistudioModelId?: string
 	requestTimeoutMs?: number
 	onRetryAttempt?: (attempt: number, maxRetries: number, delay: number, error: any) => void
 }

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1062,6 +1062,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					return `vscode-lm:${apiConfiguration.vsCodeLmModelSelector ? `${apiConfiguration.vsCodeLmModelSelector.vendor ?? ""}/${apiConfiguration.vsCodeLmModelSelector.family ?? ""}` : unknownModel}`
 				case "together":
 					return `${selectedProvider}:${apiConfiguration.togetherModelId}`
+				case "aistudio":
+					return `${selectedProvider}:${apiConfiguration.aistudioModelId}`
 				case "fireworks":
 					return `fireworks:${apiConfiguration.fireworksModelId}`
 				case "lmstudio":

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -319,6 +319,7 @@ const ApiOptions = ({
 					<VSCodeOption value="requesty">Requesty</VSCodeOption>
 					<VSCodeOption value="fireworks">Fireworks</VSCodeOption>
 					<VSCodeOption value="together">Together</VSCodeOption>
+					<VSCodeOption value="aistudio">AiStudio</VSCodeOption>
 					<VSCodeOption value="qwen">Alibaba Qwen</VSCodeOption>
 					<VSCodeOption value="doubao">Bytedance Doubao</VSCodeOption>
 					<VSCodeOption value="lmstudio">LM Studio</VSCodeOption>
@@ -1495,6 +1496,26 @@ const ApiOptions = ({
 				</div>
 			)}
 
+			{selectedProvider === "aistudio" && (
+				<div>
+					<VSCodeTextField
+						value={apiConfiguration?.aistudioApiKey || ""}
+						style={{ width: "100%" }}
+						type="password"
+						onInput={handleInputChange("aistudioApiKey")}
+						placeholder="Enter API Key...">
+						<span style={{ fontWeight: 500 }}>API Key</span>
+					</VSCodeTextField>
+					<VSCodeTextField
+						value={apiConfiguration?.aistudioModelId || ""}
+						style={{ width: "100%" }}
+						onInput={handleInputChange("aistudioModelId")}
+						placeholder={"Enter Model ID..."}>
+						<span style={{ fontWeight: 500 }}>Model ID</span>
+					</VSCodeTextField>
+				</div>
+			)}
+
 			{selectedProvider === "vscode-lm" && (
 				<div>
 					<DropdownContainer zIndex={DROPDOWN_Z_INDEX - 2} className="dropdown-container">
@@ -2450,6 +2471,12 @@ export function normalizeApiConfiguration(apiConfiguration?: ApiConfiguration): 
 				selectedProvider: provider,
 				selectedModelId: apiConfiguration?.openRouterModelId || openRouterDefaultModelId,
 				selectedModelInfo: apiConfiguration?.openRouterModelInfo || openRouterDefaultModelInfo,
+			}
+		case "aistudio":
+			return {
+				selectedProvider: provider,
+				selectedModelId: apiConfiguration?.aistudioModelId || "",
+				selectedModelInfo: openAiModelInfoSaneDefaults,
 			}
 		case "openai":
 			return {

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -83,6 +83,11 @@ export function validateApiConfiguration(apiConfiguration?: ApiConfiguration): s
 					return "You must provide a valid API key or choose a different provider."
 				}
 				break
+			case "aistudio":
+				if (!apiConfiguration.aistudioApiKey || !apiConfiguration.aistudioModelId) {
+					return "You must provide a valid API key or choose a different provider."
+				}
+				break
 			case "ollama":
 				if (!apiConfiguration.ollamaModelId) {
 					return "You must provide a valid model ID."


### PR DESCRIPTION
## Summary
- implement new `AiStudioHandler` provider
- integrate `aistudio` option across settings and state
- support AiStudio in UI components and validation

## Testing
- `npm test` *(fails: Cannot find module 'esbuild')*